### PR TITLE
Update __init__.py

### DIFF
--- a/custom_components/enphase_envoy_custom/__init__.py
+++ b/custom_components/enphase_envoy_custom/__init__.py
@@ -128,7 +128,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         NAME: name,
     }
 
-    hass.config_entries.async_setup_platforms(entry, PLATFORMS)
+    await hass.config_entries.async_forward_entry_setups (entry, PLATFORMS)
 
     return True
 


### PR DESCRIPTION
This is a fix for the upcoming change in Home Assistant 2023.3. See for reference: https://community.home-assistant.io/t/async-forward-entry-setups-this-will-fail-in-version-2023-3/533293?u=ha_n00b

According to Tweakers.net (https://gathering.tweakers.net/forum/view_message/74430624) this issue is already succesfully fixed in the forked version of Posixx (https://github.com/posixx/home_assistant_custom_envoy/blob/main/custom_components/enphase_envoy_custom/__init__.py).

I’ve created this change request to get it fixed in your fork as well.