### PR TITLE
Replace current async_setup_platforms function with async_forward_ent…

### DIFF
--- a/custom_components/enphase_envoy_custom/__init__.py
+++ b/custom_components/enphase_envoy_custom/__init__.py
@@ -128,7 +128,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         NAME: name,
     }
 
-    hass.config_entries.async_setup_platforms(entry, PLATFORMS)
+    await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
 
     return True
 


### PR DESCRIPTION
Fixed an error 'ConfigEntries' object has no attribute 'async_setup_platforms', which was caused by an deprecated feature which will prevent the integration failing to start in Home Assistant 2023.5+

The function async_setup_platforms has been replaced.

Logger: homeassistant.config_entries
Source: custom_components/enphase_envoy/init.py:131
Integration: Enphase Envoy (DEV)
First occurred: 20:53:37 (1 occurrences)
Last logged: 20:53:37 

Error setting up entry Envoy <code> for enphase_envoy
Traceback (most recent call last):
File "/usr/src/homeassistant/homeassistant/config_entries.py", line 387, in async_setup
result = await component.async_setup_entry(hass, self)
File "/config/custom_components/enphase_envoy/init.py", line 131, in async_setup_entry
hass.config_entries.async_setup_platforms(entry, PLATFORMS)
AttributeError: 'ConfigEntries' object has no attribute 'async_setup_platforms'